### PR TITLE
fix(platforms): fails when any platform doesn't have `specificationId`

### DIFF
--- a/Emudeck/EmudeckConfigurator.cs
+++ b/Emudeck/EmudeckConfigurator.cs
@@ -82,7 +82,9 @@ namespace EmudeckPlaynite
 
                 savedPlatforms.ForEach(s =>
                 {
-                    platforms.Add(s.SpecificationId, new Guid(s.Id.ToString()));
+                    if (s.SpecificationId != null) {
+                        platforms.Add(s.SpecificationId, new Guid(s.Id.ToString()));
+                    }
                 });
 
 


### PR DESCRIPTION
When there's any platform in your library that doesn't have a `specificationId` (ex: when adding a custom platform, or when importing from metadata providers), this line halts the entire process of configuring emulators.